### PR TITLE
Add 'receive' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.13"
 edition = "2021"
 rust-version = "1.70"
 
+[features]
+default = ["receive"]
+receive = ["dep:meshtastic"]
+
 [build-dependencies]
 prost-build = "=0.13.2"
 protoc-bin-vendored = "3.1.0"
@@ -13,7 +17,7 @@ walkdir = "2.3.2"
 chrono = "0.4.38"
 geoutils = "0.5.1"
 log = "0.4.20"
-meshtastic = { git = "https://github.com/meshtastic/rust.git", rev = "7410cefb3747ee7c8b6dc81a182ed91b810f9e20" }
+meshtastic = { git = "https://github.com/meshtastic/rust.git", rev = "7410cefb3747ee7c8b6dc81a182ed91b810f9e20", optional = true }
 prost = "=0.13.2"
 pyo3 = { version = "0.22.0", features = ["extension-module", "chrono", "abi3-py311"] }
 pyo3-log = "0.11.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 //pub mod async_serial;
 pub mod logs;
+#[cfg(feature = "receive")]
+pub mod meshtastic;
+#[cfg(feature = "receive")]
 pub mod message_handler;
 pub mod punch;
 pub mod python;

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -1,11 +1,6 @@
 use chrono::prelude::*;
 use chrono::{DateTime, Duration};
-use meshtastic::protobufs::mesh_packet::PayloadVariant;
-use meshtastic::protobufs::{telemetry, Data, ServiceEnvelope, Telemetry};
-use meshtastic::protobufs::{MeshPacket, PortNum, Position as PositionProto};
-use meshtastic::Message as MeshtaticMessage;
 use pyo3::prelude::*;
-use std::collections::HashMap;
 use std::fmt;
 
 use crate::protobufs::{status::Msg, DeviceEvent, Disconnected, Status};
@@ -162,7 +157,7 @@ impl fmt::Display for MiniCallHome {
 pub struct RssiSnr {
     pub rssi_dbm: i16,
     pub snr: f32,
-    distance: Option<(f32, String)>,
+    pub distance: Option<(f32, String)>,
 }
 
 impl RssiSnr {
@@ -182,66 +177,9 @@ impl RssiSnr {
     }
 }
 
-#[pyclass]
-pub struct MshLogMessage {
-    pub host_info: HostInfo,
-    pub voltage_battery: Option<(f32, u32)>,
-    pub position: Option<Position>,
-    pub rssi_snr: Option<RssiSnr>,
-    timestamp: DateTime<FixedOffset>,
-    latency: Duration,
-}
-
-const TELEMETRY_APP: i32 = PortNum::TelemetryApp as i32;
-const POSITION_APP: i32 = PortNum::PositionApp as i32;
-
-#[pymethods]
-impl MshLogMessage {
-    pub fn __repr__(&self) -> String {
-        format!("{}", self)
-    }
-}
-
-impl fmt::Display for MshLogMessage {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let timestamp = self.timestamp.format("%H:%M:%S");
-        write!(f, "{} {timestamp}:", self.host_info.name)?;
-        if let Some((voltage, battery)) = self.voltage_battery {
-            write!(f, " batt {:.3}V {}%", voltage, battery)?;
-        }
-        if let Some(Position {
-            lat,
-            lon,
-            elevation,
-            ..
-        }) = self.position
-        {
-            write!(f, " coords {:.5} {:.5} {}m", lat, lon, elevation)?;
-        }
-        let millis = self.latency.num_milliseconds() as f64 / 1000.0;
-        write!(f, ", latency {:4.2}s", millis)?;
-        if let Some(RssiSnr {
-            rssi_dbm,
-            snr,
-            distance,
-        }) = &self.rssi_snr
-        {
-            match distance {
-                None => write!(f, ", {}dBm {:.2}SNR", rssi_dbm, snr)?,
-                Some((meters, name)) => write!(
-                    f,
-                    ", {rssi_dbm}dBm {snr:.2}SNR, {:.2}km from {name}",
-                    meters / 1000.0,
-                )?,
-            }
-        };
-        Ok(())
-    }
-}
-
 pub struct PositionName {
-    position: Position,
-    name: String,
+    pub position: Position,
+    pub name: String,
 }
 
 impl PositionName {
@@ -253,198 +191,13 @@ impl PositionName {
     }
 }
 
-impl MshLogMessage {
-    pub fn timestamp(posix_time: u32) -> DateTime<FixedOffset> {
-        time::datetime_from_timestamp(u64::from(posix_time) * 1000, &Local)
-    }
-
-    fn parse_inner(
-        data: Data,
-        host_info: HostInfo,
-        now: DateTime<FixedOffset>,
-        mut rssi_snr: Option<RssiSnr>,
-        recv_position: Option<PositionName>,
-    ) -> Result<Option<Self>, std::io::Error> {
-        match data.portnum {
-            TELEMETRY_APP => {
-                let telemetry = Telemetry::decode(data.payload.as_slice())?;
-                let timestamp = Self::timestamp(telemetry.time);
-                match telemetry.variant {
-                    Some(telemetry::Variant::DeviceMetrics(metrics)) => Ok(Some(Self {
-                        host_info,
-                        timestamp,
-                        latency: now - timestamp,
-                        voltage_battery: Some((metrics.voltage, metrics.battery_level)),
-                        position: None,
-                        rssi_snr,
-                    })),
-                    _ => Ok(None),
-                }
-            }
-            POSITION_APP => {
-                let position = PositionProto::decode(data.payload.as_slice())?;
-                if position.latitude_i == 0 && position.longitude_i == 0 {
-                    return Ok(None);
-                }
-                let timestamp = Self::timestamp(position.time);
-                let position = Position {
-                    lat: position.latitude_i as f32 / 10_000_000.,
-                    lon: position.longitude_i as f32 / 10_000_000.,
-                    elevation: position.altitude,
-                    timestamp: Self::timestamp(position.time),
-                };
-                let distance = recv_position
-                    .as_ref()
-                    .map(|other| position.distance_m(&other.position));
-                if let Some(Ok(distance)) = distance {
-                    rssi_snr.as_mut().map(|rssi_snr| {
-                        rssi_snr.add_distance(
-                            distance as f32,
-                            recv_position.map(|x| x.name).unwrap_or_default(),
-                        )
-                    });
-                }
-
-                Ok(Some(Self {
-                    host_info,
-                    timestamp,
-                    latency: now - timestamp,
-                    voltage_battery: None,
-                    position: Some(position),
-                    rssi_snr,
-                }))
-            }
-            _ => Ok(None),
-        }
-    }
-
-    pub fn from_msh_status(
-        payload: &[u8],
-        now: DateTime<FixedOffset>,
-        dns: &HashMap<String, String>,
-        recv_position: Option<PositionName>,
-    ) -> Result<Option<Self>, std::io::Error> {
-        let service_envelope = ServiceEnvelope::decode(payload)?;
-        match service_envelope.packet {
-            Some(MeshPacket {
-                payload_variant: Some(PayloadVariant::Decoded(data)),
-                from,
-                rx_rssi,
-                rx_snr,
-                ..
-            }) => {
-                let mac_address = format!("{:8x}", from);
-                let name = dns
-                    .get(&mac_address)
-                    .map(|x| x.as_str())
-                    .unwrap_or("Unknown");
-                Self::parse_inner(
-                    data,
-                    HostInfo {
-                        name: name.to_owned(),
-                        mac_address,
-                    },
-                    now,
-                    RssiSnr::new(rx_rssi, rx_snr),
-                    recv_position,
-                )
-            }
-            Some(MeshPacket {
-                payload_variant: Some(PayloadVariant::Encrypted(_)),
-                ..
-            }) => Err(
-                prost::DecodeError::new("Encrypted message, disable encryption in MQTT!").into(),
-            ),
-            _ => Ok(None),
-        }
-    }
-}
-
 #[cfg(test)]
 mod test_logs {
     use chrono::{DateTime, Duration};
 
-    use crate::{
-        logs::{CellularLogMessage, HostInfo, RssiSnr},
-        status::Position,
-    };
+    use crate::logs::{CellularLogMessage, HostInfo};
 
-    use super::{MiniCallHome, MshLogMessage};
-
-    #[test]
-    fn test_volt_batt() {
-        let timestamp = DateTime::parse_from_rfc3339("2024-01-29T21:34:49+01:00").unwrap();
-        let log_message = MshLogMessage {
-            host_info: HostInfo {
-                name: "spr01".to_owned(),
-                mac_address: String::new(),
-            },
-            timestamp,
-            latency: Duration::milliseconds(1230),
-            voltage_battery: Some((4.012, 82)),
-            position: None,
-            rssi_snr: None,
-        };
-        assert_eq!(
-            format!("{log_message}"),
-            "spr01 21:34:49: batt 4.012V 82%, latency 1.23s"
-        );
-    }
-
-    #[test]
-    fn test_position() {
-        let timestamp = DateTime::parse_from_rfc3339("2024-01-29T13:15:25+01:00").unwrap();
-        let log_message = MshLogMessage {
-            host_info: HostInfo {
-                name: "spr01".to_owned(),
-                mac_address: String::new(),
-            },
-            timestamp,
-            latency: Duration::milliseconds(1230),
-            position: Some(Position {
-                lat: 48.29633,
-                lon: 17.26675,
-                elevation: 170,
-                timestamp,
-            }),
-            voltage_battery: None,
-            rssi_snr: None,
-        };
-        assert_eq!(
-            format!("{log_message}"),
-            "spr01 13:15:25: coords 48.29633 17.26675 170m, latency 1.23s",
-        );
-    }
-
-    #[test]
-    fn test_position_dbm() {
-        let timestamp = DateTime::parse_from_rfc3339("2024-01-29T13:15:25+01:00").unwrap();
-        let log_message = MshLogMessage {
-            host_info: HostInfo {
-                name: "spr01".to_owned(),
-                mac_address: String::new(),
-            },
-            timestamp,
-            latency: Duration::milliseconds(1230),
-            position: Some(Position {
-                lat: 48.29633,
-                lon: 17.26675,
-                elevation: 170,
-                timestamp,
-            }),
-            voltage_battery: None,
-            rssi_snr: Some(RssiSnr {
-                rssi_dbm: -80,
-                snr: 4.25,
-                distance: Some((813., "spr02".to_string())),
-            }),
-        };
-        assert_eq!(
-            format!("{log_message}"),
-            "spr01 13:15:25: coords 48.29633 17.26675 170m, latency 1.23s, -80dBm 4.25SNR, 0.81km \
-            from spr02"
-        );
-    }
+    use super::MiniCallHome;
 
     #[test]
     fn test_cellular_dbm() {

--- a/src/meshtastic.rs
+++ b/src/meshtastic.rs
@@ -1,0 +1,263 @@
+use chrono::prelude::*;
+use chrono::{DateTime, Duration};
+use meshtastic::protobufs::mesh_packet::PayloadVariant;
+use meshtastic::protobufs::{telemetry, Data, ServiceEnvelope, Telemetry};
+use meshtastic::protobufs::{MeshPacket, PortNum, Position as PositionProto};
+use meshtastic::Message as MeshtaticMessage;
+use pyo3::prelude::*;
+use std::collections::HashMap;
+use std::fmt;
+
+use crate::logs::{HostInfo, PositionName, RssiSnr};
+use crate::status::Position;
+use crate::time::datetime_from_timestamp;
+
+#[pyclass]
+pub struct MshLogMessage {
+    pub host_info: HostInfo,
+    pub voltage_battery: Option<(f32, u32)>,
+    pub position: Option<Position>,
+    pub rssi_snr: Option<RssiSnr>,
+    timestamp: DateTime<FixedOffset>,
+    latency: Duration,
+}
+
+impl MshLogMessage {
+    pub fn timestamp(posix_time: u32) -> DateTime<FixedOffset> {
+        datetime_from_timestamp(u64::from(posix_time) * 1000, &Local)
+    }
+
+    fn parse_inner(
+        data: Data,
+        host_info: HostInfo,
+        now: DateTime<FixedOffset>,
+        mut rssi_snr: Option<RssiSnr>,
+        recv_position: Option<PositionName>,
+    ) -> Result<Option<Self>, std::io::Error> {
+        match data.portnum {
+            TELEMETRY_APP => {
+                let telemetry = Telemetry::decode(data.payload.as_slice())?;
+                let timestamp = Self::timestamp(telemetry.time);
+                match telemetry.variant {
+                    Some(telemetry::Variant::DeviceMetrics(metrics)) => Ok(Some(Self {
+                        host_info,
+                        timestamp,
+                        latency: now - timestamp,
+                        voltage_battery: Some((metrics.voltage, metrics.battery_level)),
+                        position: None,
+                        rssi_snr,
+                    })),
+                    _ => Ok(None),
+                }
+            }
+            POSITION_APP => {
+                let position = PositionProto::decode(data.payload.as_slice())?;
+                if position.latitude_i == 0 && position.longitude_i == 0 {
+                    return Ok(None);
+                }
+                let timestamp = Self::timestamp(position.time);
+                let position = Position {
+                    lat: position.latitude_i as f32 / 10_000_000.,
+                    lon: position.longitude_i as f32 / 10_000_000.,
+                    elevation: position.altitude,
+                    timestamp: Self::timestamp(position.time),
+                };
+                let distance = recv_position
+                    .as_ref()
+                    .map(|other| position.distance_m(&other.position));
+                if let Some(Ok(distance)) = distance {
+                    rssi_snr.as_mut().map(|rssi_snr| {
+                        rssi_snr.add_distance(
+                            distance as f32,
+                            recv_position.map(|x| x.name).unwrap_or_default(),
+                        )
+                    });
+                }
+
+                Ok(Some(Self {
+                    host_info,
+                    timestamp,
+                    latency: now - timestamp,
+                    voltage_battery: None,
+                    position: Some(position),
+                    rssi_snr,
+                }))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    pub fn from_msh_status(
+        payload: &[u8],
+        now: DateTime<FixedOffset>,
+        dns: &HashMap<String, String>,
+        recv_position: Option<PositionName>,
+    ) -> Result<Option<Self>, std::io::Error> {
+        let service_envelope = ServiceEnvelope::decode(payload)?;
+        match service_envelope.packet {
+            Some(MeshPacket {
+                payload_variant: Some(PayloadVariant::Decoded(data)),
+                from,
+                rx_rssi,
+                rx_snr,
+                ..
+            }) => {
+                let mac_address = format!("{:8x}", from);
+                let name = dns
+                    .get(&mac_address)
+                    .map(|x| x.as_str())
+                    .unwrap_or("Unknown");
+                Self::parse_inner(
+                    data,
+                    HostInfo {
+                        name: name.to_owned(),
+                        mac_address,
+                    },
+                    now,
+                    RssiSnr::new(rx_rssi, rx_snr),
+                    recv_position,
+                )
+            }
+            Some(MeshPacket {
+                payload_variant: Some(PayloadVariant::Encrypted(_)),
+                ..
+            }) => Err(
+                prost::DecodeError::new("Encrypted message, disable encryption in MQTT!").into(),
+            ),
+            _ => Ok(None),
+        }
+    }
+}
+
+const TELEMETRY_APP: i32 = PortNum::TelemetryApp as i32;
+const POSITION_APP: i32 = PortNum::PositionApp as i32;
+
+#[pymethods]
+impl MshLogMessage {
+    pub fn __repr__(&self) -> String {
+        format!("{}", self)
+    }
+}
+
+impl fmt::Display for MshLogMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let timestamp = self.timestamp.format("%H:%M:%S");
+        write!(f, "{} {timestamp}:", self.host_info.name)?;
+        if let Some((voltage, battery)) = self.voltage_battery {
+            write!(f, " batt {:.3}V {}%", voltage, battery)?;
+        }
+        if let Some(Position {
+            lat,
+            lon,
+            elevation,
+            ..
+        }) = self.position
+        {
+            write!(f, " coords {:.5} {:.5} {}m", lat, lon, elevation)?;
+        }
+        let millis = self.latency.num_milliseconds() as f64 / 1000.0;
+        write!(f, ", latency {:4.2}s", millis)?;
+        if let Some(RssiSnr {
+            rssi_dbm,
+            snr,
+            distance,
+        }) = &self.rssi_snr
+        {
+            match distance {
+                None => write!(f, ", {}dBm {:.2}SNR", rssi_dbm, snr)?,
+                Some((meters, name)) => write!(
+                    f,
+                    ", {rssi_dbm}dBm {snr:.2}SNR, {:.2}km from {name}",
+                    meters / 1000.0,
+                )?,
+            }
+        };
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test_meshtastic {
+    use chrono::{DateTime, Duration};
+
+    use crate::{
+        logs::{HostInfo, RssiSnr},
+        meshtastic::MshLogMessage,
+        status::Position,
+    };
+
+    #[test]
+    fn test_volt_batt() {
+        let timestamp = DateTime::parse_from_rfc3339("2024-01-29T21:34:49+01:00").unwrap();
+        let log_message = MshLogMessage {
+            host_info: HostInfo {
+                name: "spr01".to_owned(),
+                mac_address: String::new(),
+            },
+            timestamp,
+            latency: Duration::milliseconds(1230),
+            voltage_battery: Some((4.012, 82)),
+            position: None,
+            rssi_snr: None,
+        };
+        assert_eq!(
+            format!("{log_message}"),
+            "spr01 21:34:49: batt 4.012V 82%, latency 1.23s"
+        );
+    }
+
+    #[test]
+    fn test_position() {
+        let timestamp = DateTime::parse_from_rfc3339("2024-01-29T13:15:25+01:00").unwrap();
+        let log_message = MshLogMessage {
+            host_info: HostInfo {
+                name: "spr01".to_owned(),
+                mac_address: String::new(),
+            },
+            timestamp,
+            latency: Duration::milliseconds(1230),
+            position: Some(Position {
+                lat: 48.29633,
+                lon: 17.26675,
+                elevation: 170,
+                timestamp,
+            }),
+            voltage_battery: None,
+            rssi_snr: None,
+        };
+        assert_eq!(
+            format!("{log_message}"),
+            "spr01 13:15:25: coords 48.29633 17.26675 170m, latency 1.23s",
+        );
+    }
+
+    #[test]
+    fn test_position_dbm() {
+        let timestamp = DateTime::parse_from_rfc3339("2024-01-29T13:15:25+01:00").unwrap();
+        let log_message = MshLogMessage {
+            host_info: HostInfo {
+                name: "spr01".to_owned(),
+                mac_address: String::new(),
+            },
+            timestamp,
+            latency: Duration::milliseconds(1230),
+            position: Some(Position {
+                lat: 48.29633,
+                lon: 17.26675,
+                elevation: 170,
+                timestamp,
+            }),
+            voltage_battery: None,
+            rssi_snr: Some(RssiSnr {
+                rssi_dbm: -80,
+                snr: 4.25,
+                distance: Some((813., "spr02".to_string())),
+            }),
+        };
+        assert_eq!(
+            format!("{log_message}"),
+            "spr01 13:15:25: coords 48.29633 17.26675 170m, latency 1.23s, -80dBm 4.25SNR, 0.81km \
+            from spr02"
+        );
+    }
+}

--- a/src/message_handler.rs
+++ b/src/message_handler.rs
@@ -11,7 +11,8 @@ use std::collections::HashMap;
 use chrono::prelude::*;
 use chrono::DateTime;
 
-use crate::logs::{CellularLogMessage, HostInfo, MshLogMessage, PositionName};
+use crate::logs::{CellularLogMessage, HostInfo, PositionName};
+use crate::meshtastic::MshLogMessage;
 use crate::protobufs::{Punches, Status};
 use crate::punch::SiPunch;
 use crate::punch::SiPunchLog;

--- a/src/python.rs
+++ b/src/python.rs
@@ -64,10 +64,13 @@ pub fn rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<crate::punch::SiPunchLog>()?;
     m.add_class::<crate::logs::HostInfo>()?;
     m.add_class::<crate::logs::MiniCallHome>()?;
-    m.add_class::<crate::logs::MshLogMessage>()?;
-    m.add_class::<crate::message_handler::MessageHandler>()?;
     m.add_class::<RaspberryModel>()?;
     m.add_function(wrap_pyfunction!(current_timestamp_millis, m)?)?;
+
+    #[cfg(feature = "receive")]
+    m.add_class::<crate::meshtastic::MshLogMessage>()?;
+    #[cfg(feature = "receive")]
+    m.add_class::<crate::message_handler::MessageHandler>()?;
 
     pyo3_log::init();
     Ok(())


### PR DESCRIPTION
It can be turned off for devices that only send, e.g. online controls placed in the forest.