### PR TITLE
Move common/at module under 'at' feature

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -5,12 +5,13 @@ edition = "2021"
 
 [features]
 default = []
+at = ["dep:embassy-executor"]
 defmt = ["dep:defmt"]
 
 [dependencies]
 chrono = { workspace = true }
 defmt = { workspace = true, optional = true }
-embassy-executor = { workspace = true }
+embassy-executor = { workspace = true, optional = true }
 embassy-sync = { workspace = true }
 femtopb = { workspace = true }
 heapless =  { workspace = true }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+#[cfg(feature = "at")]
 pub mod at;
 pub mod error;
 pub mod punch;

--- a/nrf52840/Cargo.toml
+++ b/nrf52840/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.81"
 bluetooth-le = ["dep:nrf-softdevice"]
 
 [dependencies]
-common = { path = "../common", features = ["defmt"] }
+common = { path = "../common", features = ["at", "defmt"] }
 
 defmt = { workspace = true }
 defmt-rtt = "0.4"


### PR DESCRIPTION
This fixes compilation issues in Python, we can deal with this later.