### PR TITLE
Implement task for resending failed messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.dependencies]
 chrono = { version = "0.4.38", default-features = false }
 defmt = "0.3"
-embassy-executor = { version = "0.7", features = ["task-arena-size-8192", "executor-thread"] }
+embassy-executor = { version = "0.7", features = ["task-arena-size-65536", "executor-thread"] }
 embassy-futures = "0.1.1"
 embassy-nrf = { version = "0.3", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time", "nfc-pins-as-gpio"] }
 embassy-sync = "0.6.1"

--- a/common/src/at/mqtt.rs
+++ b/common/src/at/mqtt.rs
@@ -1,4 +1,4 @@
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum StatusCode {
     Published,
     Retrying(u8),


### PR DESCRIPTION
The complexity of BackoffRetries is greatly simplified:
* No priority queue anymore
* Retrying one message is handled by a single function. It's much easier to spot bugs.

There is an additional complexity due to embassy's rules, a task can't be generic. We circumvent this by adding `SendPunchFn::spawn()` function, which spawns `BackoffRetries::try_sending_with_retries()` using `SendPunchFn` implementation.

The big disadvantage of this approach is a much bigger task arena. However, at least right now we have plenty of memory, so it's not a problem but it might be in the future.